### PR TITLE
Add cookie and event checking

### DIFF
--- a/config/banners.js
+++ b/config/banners.js
@@ -30,20 +30,38 @@ export const bannerConfig = {
 	selectors: {
 		banner_visible: '.banner-position--state-finished',
 		banner_hidden: '.wmde-banner--hidden',
+		banner_soft_close: '.wmde-banner--soft-closing',
 		followup_visible: '.wmde-banner-followup-banner-position--state-finished',
 		close_button: {
+			desktop: '.wmde-banner-close-link',
 			mini: '.wmde-banner-mini-close-button',
 			full: '.wmde-banner-full-close'
 		},
 		submit_button: {
 			mini: '.wmde-banner-mini-button',
-			form: '.wmde-banner-form-button'
+			form: '.wmde-banner-form-button',
+			form_step_1: '.wmde-banner-form-step-1 .wmde-banner-form-button',
+			form_step_2: '.wmde-banner-form-step-2 .wmde-banner-form-button',
+		},
+		use_of_funds: {
+			link: '.wmde-banner-footer-usage-link',
+			modal_is_open: '.banner_modal.is-visible',
+			call_to_action: '.use_of_funds__button',
+			elements: {
+				top_section: '.use_of_funds__section',
+				text: '.use_of_funds__info_text',
+				benefits_list: '.use_of_funds__benefits_list',
+				comparison: '.use_of_funds__comparison',
+				orgchart: '.use_of_funds__orgchart_text',
+				orgchart_image: '.use_of_funds__orgchart_image',
+				donate_button: '.use_of_funds__button'
+			}
 		},
 		donation_form: {
 			interval: {
 				once: '.select-interval-0 label',
-				monthly: '..select-interval-1 label',
-				yearly: '..select-interval-12 label',
+				monthly: '.select-interval-1 label',
+				yearly: '.select-interval-12 label',
 				disabled: {
 					once: '.select-interval-0.wmde-banner-disabled input[disabled]',
 					monthly: '.select-interval-1.wmde-banner-disabled input[disabled]',
@@ -64,6 +82,32 @@ export const bannerConfig = {
 				bank_transfer: '.select-payment-method-UEB label',
 				sofort: '.select-payment-method-SUB label',
 			}
+		},
+		soft_close: {
+			maybe_later_button: '.wmde-banner-soft-close-buttons .wmde-banner-soft-close-button:first-child',
+			close_button: '.wmde-banner-soft-close-buttons .wmde-banner-soft-close-button:last-child',
 		}
 	}
+};
+
+export const intervals = {
+	once: 'once',
+	monthly: 'monthly',
+	yearly: 'yearly',
+};
+
+export const amounts = {
+	five: 'five',
+	fifteen: 'fifteen',
+	twenty_five: 'twenty_five',
+	fifty: 'fifty',
+	one_hundred: 'one_hundred',
+};
+
+export const paymentTypes = {
+	paypal: 'paypal',
+	credit_card: 'credit_card',
+	direct_debit: 'direct_debit',
+	bank_transfer: 'bank_transfer',
+	sofort: 'sofort',
 };

--- a/pages/Banner.js
+++ b/pages/Banner.js
@@ -1,13 +1,18 @@
 import createDandy from '../src/Dandy.js';
-import { bannerConfig } from '../config/banners.js';
+import { wporgRequestLogger } from '../src/wporg_request_logger.js';
 
 export default class Banner {
+	/**
+	 * @type Dandy
+	 */
 	dandy;
+
 	parameters;
+
 	selectors;
 
-	constructor( url, selectors, parameters = {}, options = {}  ) {
-		this.dandy = createDandy( url, options );
+	constructor( url, selectors, parameters = {}, options = {} ) {
+		this.dandy = createDandy( url, Object.assign( options, { requestLogger: wporgRequestLogger } ) );
 		this.parameters = new URLSearchParams( parameters );
 		this.selectors = selectors;
 
@@ -15,7 +20,12 @@ export default class Banner {
 	}
 
 	waitForBanner() {
-		this.dandy.waitForElement( bannerConfig.selectors.banner_visible, { timeout: 10000 } );
+		this.dandy.waitForElement( this.selectors.banner_visible, { timeout: 10000 } );
+		return this;
+	}
+
+	waitForSoftClose() {
+		this.dandy.waitForElement( this.selectors.banner_soft_close );
 		return this;
 	}
 
@@ -33,43 +43,119 @@ export default class Banner {
 		await this.dandy.run();
 	}
 
+	clickDesktopCloseButton() {
+		this.dandy.click( this.selectors.close_button.desktop );
+		return this;
+	}
+
 	clickMiniBannerCloseButton() {
-		this.dandy.click( bannerConfig.selectors.close_button.mini );
+		this.dandy.click( this.selectors.close_button.mini );
+		return this;
+	}
+
+	clickSoftCloseCloseButton() {
+		this.dandy.click( this.selectors.soft_close.close_button );
+		return this;
+	}
+
+	clickSoftCloseMaybeLaterButton() {
+		this.dandy.click( this.selectors.soft_close.maybe_later_button );
 		return this;
 	}
 
 	clickMiniBannerButton() {
-		this.dandy.click( bannerConfig.selectors.submit_button.mini );
+		this.dandy.click( this.selectors.submit_button.mini );
 		return this;
 	}
 
 	waitForFollowupBanner() {
-		this.dandy.waitForElement( bannerConfig.selectors.followup_visible );
+		this.dandy.waitForElement( this.selectors.followup_visible );
 		return this;
 	}
 
-	clickPaymentTypeSofortButton() {
-		this.dandy.click( bannerConfig.selectors.donation_form.payment_type.sofort );
+	clickInterval( interval ) {
+		this.dandy.click( this.selectors.donation_form.interval[ interval ] );
+		return this;
+	}
+
+	clickPaymentType( paymentType ) {
+		this.dandy.click( this.selectors.donation_form.payment_type[ paymentType ] );
+		return this;
+	}
+
+	clickAmount( amount ) {
+		this.dandy.click( this.selectors.donation_form.amount[ amount ] );
 		return this;
 	}
 
 	checkIntervalMonthlyIsDisabled() {
-		this.dandy.checkElementExists( bannerConfig.selectors.donation_form.interval.disabled.monthly );
+		this.dandy.checkElementExists( this.selectors.donation_form.interval.disabled.monthly );
 		return this;
 	}
 
 	checkIntervalMonthlyIsEnabled() {
-		this.dandy.checkElementDoesNotExist( bannerConfig.selectors.donation_form.interval.disabled.monthly );
+		this.dandy.checkElementDoesNotExist( this.selectors.donation_form.interval.disabled.monthly );
 		return this;
 	}
 
 	checkIntervalYearlyIsDisabled() {
-		this.dandy.checkElementExists( bannerConfig.selectors.donation_form.interval.disabled.yearly );
+		this.dandy.checkElementExists( this.selectors.donation_form.interval.disabled.yearly );
 		return this;
 	}
 
 	checkBannerIsHidden() {
-		this.dandy.checkElementExists( bannerConfig.selectors.banner_hidden );
+		this.dandy.checkElementExists( this.selectors.banner_hidden );
 		return this;
 	}
+
+	checkCookieExists( cookieName ) {
+		this.dandy.hasCookie( cookieName );
+		return this;
+	}
+
+	submitForm() {
+		this.dandy.click( this.selectors.submit_button.form );
+		return this;
+	}
+
+	submitFormStep1() {
+		this.dandy.click( this.selectors.submit_button.form_step_1 );
+		return this;
+	}
+
+	submitFormStep2() {
+		this.dandy.click( this.selectors.submit_button.form_step_2 );
+		return this;
+	}
+
+	checkEventWasFired( event ) {
+		this.dandy.eventWasLogged( event );
+		return this;
+	}
+
+	checkEventContainsDataKey( event, dataKey ) {
+		this.dandy.eventWasLoggedWithData( event, dataKey );
+		return this;
+	}
+
+	clickUseOfFundsLink() {
+		this.dandy.click( this.selectors.use_of_funds.link );
+		return this;
+	}
+
+	clickUseOfFundsCallToAction() {
+		this.dandy.click( this.selectors.use_of_funds.call_to_action );
+		return this;
+	}
+
+	checkUseOfFundsIsVisible() {
+		this.dandy.checkElementExists( this.selectors.use_of_funds.modal_is_open );
+		return this;
+	}
+
+	reload() {
+		this.dandy.reloadPage();
+		return this;
+	}
+
 }

--- a/src/build_banner_test_config.js
+++ b/src/build_banner_test_config.js
@@ -13,7 +13,7 @@ export default function buildBannerTestConfig( nodeArguments ) {
 		parameters,
 		options: {
 			headless: !flags.headed,
-			viewport : { width: isMobileBanner( flags.bannerName ) ? 460 : 1000, height: 1200 }
+			viewport : { width: isMobileBanner( flags.bannerName ) ? 460 : 1200, height: 1200 }
 		}
 	};
 }

--- a/src/wporg_request_logger.js
+++ b/src/wporg_request_logger.js
@@ -1,0 +1,23 @@
+const beaconEventUrl = 'https://intake-analytics.wikimedia.org/v1/events?hasty=true';
+
+export const wporgRequestLogger = {
+	log: async request => {
+		if ( request.url() === beaconEventUrl ) {
+			const data = JSON.parse( request.postData() );
+			if( data.schema === 'WMDEBannerSizeIssue' ) {
+				const eventAndBannerName = data.event.bannerName.split( '-org' );
+				return Promise.resolve( {
+					event: eventAndBannerName[ 0 ],
+					data: data.event
+				} );
+			}
+			if( data.schema === 'WMDEBannerEvents' ) {
+				return Promise.resolve( {
+					event: data.event.bannerAction,
+					data: data.event
+				} );
+			}
+			return Promise.resolve( null );
+		}
+	}
+};

--- a/tests/banners/desktop-fires-event-on-submit.js
+++ b/tests/banners/desktop-fires-event-on-submit.js
@@ -1,0 +1,20 @@
+import { amounts, bannerConfig, intervals, paymentTypes } from '../../config/banners.js';
+import Banner from '../../pages/Banner.js';
+import buildBannerTestConfig from '../../src/build_banner_test_config.js';
+
+const testConfig = buildBannerTestConfig( process.argv );
+
+( async () => {
+
+	const banner = new Banner( testConfig.url, bannerConfig.selectors, testConfig.parameters, testConfig.options );
+
+	await banner.waitForBanner()
+		.clickInterval( intervals.yearly )
+		.clickAmount( amounts.five )
+		.clickPaymentType( paymentTypes.paypal )
+		.submitFormStep1()
+		.wait( 1000 ) // Give event time to fire
+		.checkEventContainsDataKey( 'submit', 'viewportWidth' )
+		.checkEventContainsDataKey( 'submit', 'viewportHeight' )
+		.run();
+} )();

--- a/tests/banners/soft-banner-close-cookie.js
+++ b/tests/banners/soft-banner-close-cookie.js
@@ -1,19 +1,19 @@
-import { bannerConfig, paymentTypes } from '../../config/banners.js';
+import { bannerConfig } from '../../config/banners.js';
 import Banner from '../../pages/Banner.js';
 import buildBannerTestConfig from '../../src/build_banner_test_config.js';
 
 const testConfig = buildBannerTestConfig( process.argv );
 
 ( async () => {
+
 	const banner = new Banner( testConfig.url, bannerConfig.selectors, testConfig.parameters, testConfig.options );
 
 	await banner.waitForBanner()
-		.clickMiniBannerButton()
-		.waitForFollowupBanner()
-		.clickPaymentType( paymentTypes.sofort )
-		.wait(100)
-		.checkIntervalMonthlyIsDisabled()
-		.checkIntervalYearlyIsDisabled()
-		.captureScreenshot( `banners/${ testConfig.bannerName }/02-sofort-is-once-off-only.png` )
+		.clickDesktopCloseButton()
+		.waitForSoftClose()
+		.clickSoftCloseCloseButton()
+		.wait( 500 ) // Give the cookie time to be set
+		.checkCookieExists( 'centralnotice_hide_fundraising' )
+		.captureScreenshot( `banners/${ testConfig.bannerName }/banner-loads.png` )
 		.run();
 } )();

--- a/tests/banners/use-of-funds-cta-event-fires.js
+++ b/tests/banners/use-of-funds-cta-event-fires.js
@@ -1,19 +1,21 @@
-import { bannerConfig, paymentTypes } from '../../config/banners.js';
+import { amounts, bannerConfig, intervals, paymentTypes } from '../../config/banners.js';
 import Banner from '../../pages/Banner.js';
 import buildBannerTestConfig from '../../src/build_banner_test_config.js';
 
 const testConfig = buildBannerTestConfig( process.argv );
 
 ( async () => {
+
 	const banner = new Banner( testConfig.url, bannerConfig.selectors, testConfig.parameters, testConfig.options );
 
 	await banner.waitForBanner()
-		.clickMiniBannerButton()
-		.waitForFollowupBanner()
-		.clickPaymentType( paymentTypes.sofort )
-		.wait(100)
-		.checkIntervalMonthlyIsDisabled()
-		.checkIntervalYearlyIsDisabled()
-		.captureScreenshot( `banners/${ testConfig.bannerName }/02-sofort-is-once-off-only.png` )
+		.clickUseOfFundsLink()
+		.clickUseOfFundsCallToAction()
+
+		// Reloading forces the event to fire
+		.reload()
+		.wait( 1000 )
+
+		.checkEventWasFired( 'funds-modal-donate-clicked' )
 		.run();
 } )();


### PR DESCRIPTION
This adds functionality to Dandy to check page
cookies and events.

It checks the events by monitoring network
requests and putting specified ones into an
event log. It also provides methods to see
if an event was fired and if it was fired
with data.